### PR TITLE
[JENKINS-25625] Avoid this library

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 This small module allows Jenkins plugins to incorporate the SECURITY-144 protection in newer versions of Jenkins core,
 while still remaining installable on earlier version of Jenkins.
 
+Due to the unresolved [JENKINS-25625](https://issues.jenkins-ci.org/browse/JENKINS-25625), it is no longer recommended you use this library.
+Instead just update your plugin’s core baseline to 1.580.1 or newer, which will no longer exclude many users from receiving plugin updates.
+
 ## Problem
 [The SECURITY-144 protection work](http://jenkins-ci.org/security-144/) required API changes in the core as well as the `remoting` library.
 Therefore, for your plugin to take advantages of the new infrastructure, you'll have to bump up the core dependency.

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <artifactId>SECURITY-144-compat</artifactId>
   
   <version>1.1-SNAPSHOT</version>
-  <name>Compatibility Layer for SECURITY-144</name>
+  <name>Deprecated compatibility layer for SECURITY-144</name>
 
   <scm>
     <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}.git</connection>

--- a/src/main/java/jenkins/MasterToSlaveFileCallable.java
+++ b/src/main/java/jenkins/MasterToSlaveFileCallable.java
@@ -9,6 +9,7 @@ import org.jenkinsci.remoting.RoleSensitive;
  * {@link FileCallable}s that are meant to be only used on the master.
  * @deprecated Use a core dependency of 1.580.1 or later rather than this library.
  */
+@Deprecated
 public abstract class MasterToSlaveFileCallable<T> implements FileCallable<T>, RoleSensitive {
     public void checkRoles(RoleChecker checker) throws SecurityException {
         // no check actually happens when this class definition is used, so this code will never run

--- a/src/main/java/jenkins/MasterToSlaveFileCallable.java
+++ b/src/main/java/jenkins/MasterToSlaveFileCallable.java
@@ -7,6 +7,7 @@ import org.jenkinsci.remoting.RoleSensitive;
 
 /**
  * {@link FileCallable}s that are meant to be only used on the master.
+ * @deprecated Use a core dependency of 1.580.1 or later rather than this library.
  */
 public abstract class MasterToSlaveFileCallable<T> implements FileCallable<T>, RoleSensitive {
     public void checkRoles(RoleChecker checker) throws SecurityException {

--- a/src/main/java/jenkins/SlaveToMasterFileCallable.java
+++ b/src/main/java/jenkins/SlaveToMasterFileCallable.java
@@ -7,6 +7,7 @@ import org.jenkinsci.remoting.RoleSensitive;
 
 /**
  * {@link FileCallable}s that can be executed on the master, sent by the slave.
+ * @deprecated Use a core dependency of 1.580.1 or later rather than this library.
  */
 public abstract class SlaveToMasterFileCallable<T> implements FileCallable<T>, RoleSensitive {
     public void checkRoles(RoleChecker checker) throws SecurityException {

--- a/src/main/java/jenkins/SlaveToMasterFileCallable.java
+++ b/src/main/java/jenkins/SlaveToMasterFileCallable.java
@@ -9,6 +9,7 @@ import org.jenkinsci.remoting.RoleSensitive;
  * {@link FileCallable}s that can be executed on the master, sent by the slave.
  * @deprecated Use a core dependency of 1.580.1 or later rather than this library.
  */
+@Deprecated
 public abstract class SlaveToMasterFileCallable<T> implements FileCallable<T>, RoleSensitive {
     public void checkRoles(RoleChecker checker) throws SecurityException {
         // no check actually happens when this class definition is used, so this code will never run

--- a/src/main/java/jenkins/security/MasterToSlaveCallable.java
+++ b/src/main/java/jenkins/security/MasterToSlaveCallable.java
@@ -8,6 +8,7 @@ import org.jenkinsci.remoting.RoleSensitive;
  * Convenient {@link Callable} meant to be run on slave.
  *
  * @author Kohsuke Kawaguchi
+ * @deprecated Use a core dependency of 1.580.1 or later rather than this library.
  */
 public abstract class MasterToSlaveCallable<V, T extends Throwable> implements Callable<V,T>, RoleSensitive {
     public void checkRoles(RoleChecker checker) throws SecurityException {

--- a/src/main/java/jenkins/security/MasterToSlaveCallable.java
+++ b/src/main/java/jenkins/security/MasterToSlaveCallable.java
@@ -10,6 +10,7 @@ import org.jenkinsci.remoting.RoleSensitive;
  * @author Kohsuke Kawaguchi
  * @deprecated Use a core dependency of 1.580.1 or later rather than this library.
  */
+@Deprecated
 public abstract class MasterToSlaveCallable<V, T extends Throwable> implements Callable<V,T>, RoleSensitive {
     public void checkRoles(RoleChecker checker) throws SecurityException {
         // no check actually happens when this class definition is used, so this code will never run

--- a/src/main/java/jenkins/security/Roles.java
+++ b/src/main/java/jenkins/security/Roles.java
@@ -14,6 +14,7 @@ import org.jenkinsci.remoting.Role;
  * @author Kohsuke Kawaguchi
  * @deprecated Use a core dependency of 1.580.1 or later rather than this library.
  */
+@Deprecated
 public class Roles {
     /**
      * Indicates that a callable runs on masters, requested by slaves/CLI/maven/whatever.

--- a/src/main/java/jenkins/security/Roles.java
+++ b/src/main/java/jenkins/security/Roles.java
@@ -12,6 +12,7 @@ import org.jenkinsci.remoting.Role;
  * not have any role.
  *
  * @author Kohsuke Kawaguchi
+ * @deprecated Use a core dependency of 1.580.1 or later rather than this library.
  */
 public class Roles {
     /**

--- a/src/main/java/jenkins/security/SlaveToMasterCallable.java
+++ b/src/main/java/jenkins/security/SlaveToMasterCallable.java
@@ -10,6 +10,7 @@ import org.jenkinsci.remoting.RoleSensitive;
  * @author Kohsuke Kawaguchi
  * @deprecated Use a core dependency of 1.580.1 or later rather than this library.
  */
+@Deprecated
 public abstract class SlaveToMasterCallable<V, T extends Throwable> implements Callable<V,T>, RoleSensitive {
     public void checkRoles(RoleChecker checker) throws SecurityException {
         // no check actually happens when this class definition is used, so this code will never run

--- a/src/main/java/jenkins/security/SlaveToMasterCallable.java
+++ b/src/main/java/jenkins/security/SlaveToMasterCallable.java
@@ -8,6 +8,7 @@ import org.jenkinsci.remoting.RoleSensitive;
  * Convenient {@link Callable} that are meant to run on the master (sent by slave/CLI/etc).
  *
  * @author Kohsuke Kawaguchi
+ * @deprecated Use a core dependency of 1.580.1 or later rather than this library.
  */
 public abstract class SlaveToMasterCallable<V, T extends Throwable> implements Callable<V,T>, RoleSensitive {
     public void checkRoles(RoleChecker checker) throws SecurityException {

--- a/src/main/java/org/jenkinsci/remoting/Role.java
+++ b/src/main/java/org/jenkinsci/remoting/Role.java
@@ -46,6 +46,7 @@ import java.util.Collections;
  * @author Kohsuke Kawaguchi
  * @see RoleSensitive
  * @see RoleChecker
+ * @deprecated Use a core dependency of 1.580.1 or later rather than this library.
  */
 public final class Role {
     private final String name;

--- a/src/main/java/org/jenkinsci/remoting/Role.java
+++ b/src/main/java/org/jenkinsci/remoting/Role.java
@@ -48,6 +48,7 @@ import java.util.Collections;
  * @see RoleChecker
  * @deprecated Use a core dependency of 1.580.1 or later rather than this library.
  */
+@Deprecated
 public final class Role {
     private final String name;
 

--- a/src/main/java/org/jenkinsci/remoting/RoleChecker.java
+++ b/src/main/java/org/jenkinsci/remoting/RoleChecker.java
@@ -12,6 +12,7 @@ import java.util.Collections;
  * @see ChannelBuilder#withRoleChecker(RoleChecker)
  * @deprecated Use a core dependency of 1.580.1 or later rather than this library.
  */
+@Deprecated
 public abstract class RoleChecker {
     /**
      * Called from {@link RoleSensitive#checkRoles(RoleChecker)} to ensure that this side of the channel

--- a/src/main/java/org/jenkinsci/remoting/RoleChecker.java
+++ b/src/main/java/org/jenkinsci/remoting/RoleChecker.java
@@ -10,6 +10,7 @@ import java.util.Collections;
  *
  * @author Kohsuke Kawaguchi
  * @see ChannelBuilder#withRoleChecker(RoleChecker)
+ * @deprecated Use a core dependency of 1.580.1 or later rather than this library.
  */
 public abstract class RoleChecker {
     /**

--- a/src/main/java/org/jenkinsci/remoting/RoleSensitive.java
+++ b/src/main/java/org/jenkinsci/remoting/RoleSensitive.java
@@ -16,6 +16,7 @@ import java.util.Collection;
  * @see RoleChecker
  * @deprecated Use a core dependency of 1.580.1 or later rather than this library.
  */
+@Deprecated
 public interface RoleSensitive {
     /**
      * Verifies the roles expected by this callable by invoking {@link RoleChecker#check(RoleSensitive, Collection)}

--- a/src/main/java/org/jenkinsci/remoting/RoleSensitive.java
+++ b/src/main/java/org/jenkinsci/remoting/RoleSensitive.java
@@ -14,6 +14,7 @@ import java.util.Collection;
  *
  * @author Kohsuke Kawaguchi
  * @see RoleChecker
+ * @deprecated Use a core dependency of 1.580.1 or later rather than this library.
  */
 public interface RoleSensitive {
     /**


### PR DESCRIPTION
[JENKINS-25625](https://issues.jenkins-ci.org/browse/JENKINS-25625)

Without an implementation of [MNG-3952](https://issues.apache.org/jira/browse/MNG-3952) I do not know of any other way to discourage its use than to release a new version with all classes deprecated.

https://github.com/jenkinsci/maven-plugin/pull/45 removes the main usage. There is also a usage from `dimensionsscm-plugin` which I commented out. The current workaround in `copyartifact-plugin` must remain until a new `maven-plugin` release is made.

@reviewbybees
